### PR TITLE
make this work for FixedSizeArrays and scalars [WIP]

### DIFF
--- a/src/StructsOfArrays.jl
+++ b/src/StructsOfArrays.jl
@@ -46,7 +46,7 @@ make_iterable(x) = ScalarRepeat(x)
     arrtuple = Tuple{[Array{eltypes[i],N} for i = 1:length(eltypes)]...}
 
     :(StructOfArrays{T,$N,$arrtuple}(
-        ($([:(Array($(eltypes[i]), dims)) for i = 1:length(eltypes)]...),)
+        ($([:(Array($(eltypes[i]), (dim1, rest...))) for i = 1:length(eltypes)]...),)
     ))
 end
 StructOfArrays(T::Type, dims::Tuple{Vararg{Integer}}) = StructOfArrays(T, dims...)

--- a/src/StructsOfArrays.jl
+++ b/src/StructsOfArrays.jl
@@ -1,18 +1,70 @@
 module StructsOfArrays
-export StructOfArrays
+export StructOfArrays, ScalarRepeat
 
 immutable StructOfArrays{T,N,U<:Tuple} <: AbstractArray{T,N}
     arrays::U
 end
 
-@generated function StructOfArrays{T}(::Type{T}, dims::Integer...)
+type ScalarRepeat{T}
+    scalar::T
+end
+Base.ndims(::ScalarRepeat) = 1
+Base.getindex(s::ScalarRepeat, i...) = s.scalar
+#should setindex! really be allowed? It will set the index for the whole row...
+Base.setindex!{T}(s::ScalarRepeat{T}, value, i...) = (s.scalar = T(value))
+Base.eltype{T}(::ScalarRepeat{T}) = T
+
+Base.start(::ScalarRepeat) = 1
+Base.next(sr::ScalarRepeat, i) = sr.scalar, i+1
+Base.done(sr::ScalarRepeat, i) = false
+
+
+# since this is used in hot loops, and T.types[.] doesn't play well with compiler
+# this needs to be a generated function
+@generated function is_tuple_struct{T}(::Type{T})
+    is_ts = length(T.types) == 1 && T.types[1] <: Tuple
+    :($is_ts)
+end
+struct_eltypes{T}(struct::T) = struct_eltypes(T)
+function struct_eltypes{T}(::Type{T})
+    if is_tuple_struct(T) #special case tuple types (E.g. FixedSizeVectors)
+        return eltypes = T.types[1].parameters
+    else
+        return eltypes = T.types
+    end
+end
+
+make_iterable(x::AbstractArray) = x
+make_iterable(x) = ScalarRepeat(x)
+
+@generated function StructOfArrays{T}(::Type{T}, dim1::Integer, rest::Integer...)
     (!isleaftype(T) || T.mutable) && return :(throw(ArgumentError("can only create an StructOfArrays of leaf type immutables")))
     isempty(T.types) && return :(throw(ArgumentError("cannot create an StructOfArrays of an empty or bitstype")))
+    dims = (dim1, rest...)
     N = length(dims)
-    arrtuple = Tuple{[Array{T.types[i],N} for i = 1:length(T.types)]...}
-    :(StructOfArrays{T,$N,$arrtuple}(($([:(Array($(T.types[i]), dims)) for i = 1:length(T.types)]...),)))
+    eltypes  = struct_eltypes(T)
+    arrtuple = Tuple{[Array{eltypes[i],N} for i = 1:length(eltypes)]...}
+
+    :(StructOfArrays{T,$N,$arrtuple}(
+        ($([:(Array($(eltypes[i]), dims)) for i = 1:length(eltypes)]...),)
+    ))
 end
 StructOfArrays(T::Type, dims::Tuple{Vararg{Integer}}) = StructOfArrays(T, dims...)
+
+function StructOfArrays(T::Type, a, rest...)
+    arrays = map(make_iterable, (a, rest...))
+    N = ndims(arrays[1])
+    eltypes = map(eltype, arrays)
+    s_eltypes = struct_eltypes(T)
+    any(ix->ix[1]!=ix[2], zip(eltypes,s_eltypes)) && throw(ArgumentError(
+        "fieldtypes of $T must be equal to eltypes of arrays: $eltypes"
+    ))
+    any(x->ndims(x)!=N, arrays) && throw(ArgumentError(
+        "cannot create an StructOfArrays from arrays with different ndims"
+    ))
+    arrtuple = Tuple{map(typeof, arrays)...}
+    StructOfArrays{T, N, arrtuple}(arrays)
+end
 
 Base.linearindexing{T<:StructOfArrays}(::Type{T}) = Base.LinearFast()
 
@@ -31,18 +83,32 @@ Base.convert{T,S,N}(::Type{StructOfArrays{T}}, A::AbstractArray{S,N}) =
 Base.convert{T,N}(::Type{StructOfArrays}, A::AbstractArray{T,N}) =
     convert(StructOfArrays{T,N}, A)
 
-Base.size(A::StructOfArrays) = size(A.arrays[1])
-Base.size(A::StructOfArrays, d) = size(A.arrays[1], d)
+function Base.size(A::StructOfArrays)
+    for elem in A.arrays
+        if isa(elem, AbstractArray)
+            return size(elem)
+        end
+    end
+    ()
+end
+Base.size(A::StructOfArrays, d) = size(A)[d]
 
 @generated function Base.getindex{T}(A::StructOfArrays{T}, i::Integer...)
+    n = length(struct_eltypes(T))
     Expr(:block, Expr(:meta, :inline),
-         Expr(:new, T, [:(A.arrays[$j][i...]) for j = 1:length(T.types)]...))
+         :($T($([:(A.arrays[$j][i...]) for j = 1:n]...)))
+    )
+end
+
+function _getindex{T}(x::T, i)
+    is_tuple_struct(T) ? x[i] : getfield(x, i)
 end
 @generated function Base.setindex!{T}(A::StructOfArrays{T}, x, i::Integer...)
+    n = length(struct_eltypes(T))
     quote
         $(Expr(:meta, :inline))
         v = convert(T, x)
-        $([:(A.arrays[$j][i...] = getfield(v, $j)) for j = 1:length(T.types)]...)
+        $([:(A.arrays[$j][i...] = _getindex(v, $j)) for j = 1:n]...)
         x
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,3 +31,56 @@ small = StructOfArrays(Complex64, 2)
 @test typeof(similar(small, SubString)) === Vector{SubString}
 @test typeof(similar(small, OneField)) === Vector{OneField}
 @test typeof(similar(small, Complex128)) <: StructOfArrays
+
+immutable Vec{N,T}
+    _::NTuple{N,T}
+end
+immutable HyperCube{N,T}
+    origin::Vec{N,T}
+    width::Vec{N,T}
+end
+immutable Instance{P, S, T, R}
+    primitive::P
+    scale::S
+    translation::T
+    rotation::R
+end
+immutable ScalarRepeat{T,N} <: AbstractArray{T,N}
+    value::T
+    size::NTuple{N,Int}
+end
+Base.size(sr::ScalarRepeat) = sr.size
+Base.size(sr::ScalarRepeat, d) = sr.size[d]
+Base.getindex(sr::ScalarRepeat, i...) = sr.value
+Base.linearindexing{T<:ScalarRepeat}(::Type{T}) = Base.LinearFast()
+
+
+function test_topologic_structs()
+    hco_x,hco_yz = rand(Float32, 10), [Vec{2,Float32}((rand(Float32), rand(Float32))) for i=1:10]
+    hcw_z,hcw_xy = rand(Float32, 10), [Vec{2,Float32}((rand(Float32), rand(Float32))) for i=1:10]
+    scale = ScalarRepeat(1f0, (10,))
+    translation = ScalarRepeat(Vec{3, Float32}((2,1,3)), (10,))
+    rotation = [Vec{4, Float32}((rand(Float32),rand(Float32),rand(Float32),rand(Float32))) for i=1:10]
+    soa = StructOfArrays(
+        Instance{HyperCube{3, Float32}, Float32, Vec{3, Float32}, Vec{4,Float32}},
+        hco_x,hco_yz, hcw_xy, hcw_z, scale, translation, rotation
+    )
+    zipped = zip(hco_x,hco_yz, hcw_xy, hcw_z, scale, translation, rotation)
+    for (i,(ox,oyz, wxy, wz, s, t, r)) in enumerate(zipped)
+        instance = soa[i]
+        @test instance.primitive.origin.(1).(1) === ox
+        @test instance.primitive.origin.(1).(2) === oyz.(1).(1)
+        @test instance.primitive.origin.(1).(3) === oyz.(1).(2)
+
+        @test instance.primitive.width.(1).(1) === wxy.(1).(1)
+        @test instance.primitive.width.(1).(2) === wxy.(1).(2)
+        @test instance.primitive.width.(1).(3) === wz
+
+        @test instance.scale       === s
+        @test instance.translation === t
+        @test instance.rotation    === r
+
+    end
+end
+
+test_topologic_structs()


### PR DESCRIPTION
I need this a lot of times and made some less generic types for my own usage in GLVisualize. (Allowing particles, colors, etc, to come in different memory layouts and still being able to calculate e.g. boundingboxes for them).
I'm not sure if this is in the broader interest, especially with scalars mixed in. This could easily go into FixedSizeArrays as well, 
I plan to support even more complex constructs like, `StructOfArrays(::Vec3f0, Vector{Vec2f0}, Vector{Float32})`, or `StructOfArrays(::Vec3f0, SomeFloatIterator, Vector{Float32}, Vector{Float32})`.
WIP because this is the initial sketch to make it work and I'm not too sure about the direction yet ;)
